### PR TITLE
FreeFem++ was renamed FreeFEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# FreeFem++ Runner
-This package is a small plugin for running FreeFem++ file (.edp) from Atom editor.
+# FreeFEM Runner
+This package is a small plugin for running FreeFEM file (.edp) from Atom editor.
 
 ## Configuration
-By default, the FreeFem++ software needs to be install on your computer.
+By default, the FreeFEM software needs to be install on your computer (see the [FreeFEM documentation](https://doc.freefem.org/introduction/installation.html)).
 It also needs to be in your PATH.
 
 If not:
-> Register the path of the FreeFem++ executable in the package config
+> Register the path of the FreeFEM executable (namely FreeFem++) in the package config
 
 ## Running a .edp file
-FreeFem ++ Runner only launches .edp file.
+FreeFEM Runner only launches .edp file.
 
 This is 3 different ways to run the compilation :
 * In the package list dropdown !
-> In FreeFem++ Runner tab, "Launch compilation" tag is available
+> In FreeFEM Runner tab, "Launch compilation" tag is available
 
 * On the text editor directly
 > Right click on your code tab, in the menu a "Launch compilation for this file" tag is clickable

--- a/lib/freefem-runner-view.js
+++ b/lib/freefem-runner-view.js
@@ -22,7 +22,7 @@ export default class FreefemRunnerView {
   }
 
   getTitle() {
-    return 'FreeFem++ Runner'
+    return 'FreeFEM Runner'
   }
 
   getDefaultLocation() {

--- a/lib/freefem-runner.js
+++ b/lib/freefem-runner.js
@@ -22,7 +22,7 @@ const currentFile = (editor) => {
   }
 }
 
-const intro = [{output: '-- FreeFem++ Runner (for Atom)'}]
+const intro = [{output: '-- FreeFEM Runner (for Atom)'}]
 
 export default {
 
@@ -33,7 +33,7 @@ export default {
   config: {
     path: {
       'type': 'string',
-      'description': 'Path to the FreemFem++ executable',
+      'description': 'Path to the FreeFEM executable',
       'default': 'FreeFem++'
     }
   },
@@ -87,7 +87,7 @@ export default {
 
     if (file.extension !== '.edp') {
       atom.notifications.addError('Compilation aborted', {
-        description: `File '${file.name}'' extension (${file.extension}) doesn't match FreeFem++ file`
+        description: `File '${file.name}'' extension (${file.extension}) doesn't match FreeFEM file`
       })
 
       return

--- a/menus/freefem-runner.json
+++ b/menus/freefem-runner.json
@@ -12,7 +12,7 @@
       "label": "Packages",
       "submenu": [
         {
-          "label": "FreeFem++ Runner",
+          "label": "FreeFEM Runner",
           "submenu": [
             {
               "label": "Show compilation output",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "freefem-runner",
   "main": "./lib/freefem-runner",
   "version": "2.1.0",
-  "description": "A small package to run FreeFem++ scripts in Atom",
+  "description": "A small package to run FreeFEM scripts in Atom",
   "keywords": [
-    "freefem++",
+    "freefem",
     "script",
     "runner",
     "atom",


### PR DESCRIPTION
Just rename FreeFem++ as FreeFEM where is it possible (the FreeFEM executable is still called FreeFem++)